### PR TITLE
Expand CARD RDF to add all extra triples

### DIFF
--- a/release-notes/2025-06-18-release.md
+++ b/release-notes/2025-06-18-release.md
@@ -77,11 +77,16 @@ Example: [P28585](https://rest.uniprot.org/uniprotkb/P28585.ttl)
 uniprot:P28585
   up:classifiedWith <http://purl.obolibrary.org/obo/ARO_3001864> .
 <http://purl.obolibrary.org/obo/ARO_3001864>
+   a owl:Class ;
+   up:database database:CARD ;
    rdfs:label "CTX-M-1" ;
    rdfs:subClassOf [ owl:onProperty <http://purl.obolibrary.org/obo/RO_0000056> ;
       owl:someValuesFrom <http://purl.obolibrary.org/obo/ARO_0001004>
       ] .
-<http://purl.obolibrary.org/obo/ARO_0001004> rdfs:label "antibiotic inactivation" .
+<http://purl.obolibrary.org/obo/ARO_0001004>
+   a owl:Class ;
+   up:database database:CARD ;
+   rdfs:label "antibiotic inactivation" .
 ```
 
 ## Cross-references to FunCoup


### PR DESCRIPTION
The CARD RDF has some triples that I thought would not be interesting for users, that was wrong. So now added.